### PR TITLE
delete .word:active, etc and revert to just .word:hover

### DIFF
--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -71,15 +71,8 @@ img {
 .recipe {
     margin: 0.5rem;
 }
-.word {
+.word:hover {
     cursor: pointer;
-}
-.word:link,
-.word:visited {
-    opacity: 1;
-}
-.word:hover,
-.word:active {
     opacity: 0.5;
 }
 


### PR DESCRIPTION
I had added link behavior on class word, but it they are not links.  Removed the link css and reverted to .word:hover