### PR TITLE
Reconfigure Mobile Layout

### DIFF
--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -45,10 +45,13 @@ svg {
     display: flex;
     justify-content: center;
     align-items: center;
+
+    /*
     background-image: url("interactive-frame.png");
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
+    */
 }
 .instructions-container {
     width: inherit;

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -36,6 +36,9 @@ h2, h3 {
 }
 .svg-image-container {
     flex: 1 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 svg {
     height: 40vh;

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -34,11 +34,7 @@ h2, h3 {
     text-align: center;
     padding: 10px;
 }
-p {
-    font-size: 0.8rem;
-}
 .svg-image-container {
-    padding: 10px;
     flex: 1 1;
 }
 svg {

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -63,7 +63,7 @@ svg {
     align-items: center;
 }
 .instructions {
-    width: 50%;
+    width: 80%;
 }
 .menu {
     opacity: 0;

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -10,7 +10,7 @@ body {
     width: 100vw;
     height: 100vh;
     font-family: Verdana, Geneva, Tahoma, sans-serif;
-    color: #3f3317
+    color: #3f3317;
 }
 header {
     width: 100vw;

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -1,6 +1,5 @@
 * {
     margin: 0;
-    padding: 0;
     box-sizing: border-box;
 }
 :root {

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -81,7 +81,6 @@ svg {
     font-size: 1em;
 }
 .recipe-section {
-    margin: 2rem;
     display: flex;
     flex-direction: column;
     justify-content: space-around;

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -28,6 +28,7 @@ main {
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
+    border: 1pt solid dodgerblue;
 }
 h2, h3 {
     font-size: 1.2rem;
@@ -39,15 +40,18 @@ h2, h3 {
     display: flex;
     justify-content: center;
     align-items: center;
+    border: 1pt solid hotpink;
 }
 svg {
     height: 40vh;
+    border: 1pt solid yellow;
 }
 .menu-container {
     flex: 1 1;
     display: flex;
     justify-content: center;
     align-items: center;
+    border: 1pt solid salmon;
 
     /*
     background-image: url("interactive-frame.png");
@@ -64,9 +68,11 @@ svg {
     flex-direction: column;
     justify-content: space-around;
     align-items: center;
+    border: 1pt solid gold;
 }
 .instructions {
     width: 80%;
+    border: 1pt solid greenyellow;
 }
 .menu {
     opacity: 0;
@@ -78,16 +84,20 @@ svg {
     flex-direction: column;
     justify-content: space-evenly;
     align-items: center;
+    border: 1pt solid red;
+}
+.video-section {
+    border: 1pt solid green;
 }
 .video-link {
-    margin: 2rem;
-    font-size: 1em;
+    border: 1pt solid cyan;
 }
 .recipe-section {
     display: flex;
     flex-direction: column;
     justify-content: space-around;
     align-items: center;
+    border: 1pt solid orange;
 }
 .recipe-link-section {
     display: flex;
@@ -97,6 +107,8 @@ svg {
     gap: 10px;
     border: 1pt solid yellow;
 }
+.recipe-link {
+    border: 1pt solid blueviolet;
 }
 .word:hover {
     cursor: pointer;

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -3,7 +3,7 @@
     box-sizing: border-box;
 }
 :root {
-    --menu-width: 60vw;
+    --menu-width: 80vw;
     --menu-height: 40vh;
 }
 body {

--- a/interactive-deer.css
+++ b/interactive-deer.css
@@ -89,8 +89,14 @@ svg {
     justify-content: space-around;
     align-items: center;
 }
-.recipe {
-    margin: 0.5rem;
+.recipe-link-section {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    align-items: center;
+    gap: 10px;
+    border: 1pt solid yellow;
+}
 }
 .word:hover {
     cursor: pointer;

--- a/interactive-deer.js
+++ b/interactive-deer.js
@@ -138,7 +138,7 @@ function showMenu(e) {
 
     // if mobile, to center of bottom half
     if (window_width < 900) {
-        translate_x = window_width * 0.2 - click_x;
+        translate_x = window_width * 0.1 - click_x;
         translate_y = window_height * 0.55 - click_y + 20;
     }
     // if desktop, to 3/4 window over, 1/2 window down

--- a/interactive-deer.js
+++ b/interactive-deer.js
@@ -73,7 +73,7 @@ function showMenu(e) {
     // add header and video link to section
     newVideoSection.append(newVideoHeader, newVideoLink);
 
-    // create recipe section ( will have header and three recipe links )
+    // create recipe section ( will have header and a section of three recipe links )
     let newRecipeSection = document.createElement('div');
     newRecipeSection.classList.add("recipe-section");
 
@@ -83,7 +83,11 @@ function showMenu(e) {
     newRecipeHeader.appendChild(newRecipeHeaderText);
     newRecipeHeader.classList.add("recipe-header");
 
-    //create recipe links
+    // create recipe link section
+    let newRecipeLinkSection = document.createElement('div');
+    newRecipeLinkSection.classList.add("recipe-link-section");
+
+    // create recipe links
     let newRecipeLink1 = document.createElement('a');
     newRecipeLink1.target = "_blank";
     newRecipeLink1.title = "Click for Recipe";
@@ -107,9 +111,12 @@ function showMenu(e) {
     let recipeLinkLabel3 = document.createTextNode("Crispy Orange Peel Venison");
     newRecipeLink3.appendChild(recipeLinkLabel3);
     newRecipeLink3.classList.add("recipe-link");
+    
+    // add recipe links to recipe link section
+    newRecipeLinkSection.append(newRecipeLink1, newRecipeLink2, newRecipeLink3);
 
     // add header and recipes to recipe section
-    newRecipeSection.append(newRecipeHeader, newRecipeLink1, newRecipeLink2, newRecipeLink3);
+    newRecipeSection.append(newRecipeHeader, newRecipeLinkSection);
     
     // build entire menu
     newMenuDiv.appendChild(newVideoSection);


### PR DESCRIPTION
Add borders to make sections visible.
Increase menu area width to 80vw from 60vw as well as instruction area.
Remove background image frame from the menu area because it is too short.
Remove unneeded margin around menu sections that narrowed the area for wording to be on single lines.
Add recipe link section to put the three links in a flex box.
Add flex gap between the recipes.
